### PR TITLE
Client route#14

### DIFF
--- a/client/src/components/content/history-content/editor/editor.ts
+++ b/client/src/components/content/history-content/editor/editor.ts
@@ -104,7 +104,6 @@ export default class Editor extends Component {
 		try {
 			const paymentRes = await PaymentApi.findAll(paymentDto);
 			const payments = (await paymentRes.json()).result;
-			console.log('payments', payments);
 
 			for (let i = 0; i < payments.length; i++) {
 				const payment = document.createElement('option');
@@ -115,7 +114,6 @@ export default class Editor extends Component {
 
 			const categoryRes = await CategoryApi.findAll(categoryDto);
 			const categories = (await categoryRes.json()).result;
-			console.log('categories', categories);
 			const incomeCategories = [];
 			const outcomeCategories = [];
 			for (let i = 0; i < categories.length; i++) {

--- a/client/src/components/main-panel/main-panel.ts
+++ b/client/src/components/main-panel/main-panel.ts
@@ -1,76 +1,115 @@
+import Router, { View } from '../../router';
 import HistoryContent from '../content/history-content';
 import Component from '../component';
-import { History } from '../content/abstract-content';
 import { AbstractContent } from '../content/abstract-content';
 import MonthSelector from '../month-selector';
 import TabSelector from '../tab-selector';
 
-//날짜로 오름차순
-const testHistory: History[] = [
-	{
-		category: '밥',
-		historyDate: new Date('2020-08-01'),
-		content: '순댓국',
-		id: 1,
-		payment: '외상',
-		price: -4000,
-	},
-	{
-		category: '주식',
-		historyDate: new Date('2020-08-01'),
-		content: '상장폐지',
-		id: 2,
-		payment: '주식',
-		price: -5000,
-	},
-	{
-		category: '밥',
-		historyDate: new Date('2020-08-01'),
-		content: '순댓국1',
-		id: 3,
-		payment: '외상',
-		price: -3000,
-	},
-	{
-		category: '일',
-		historyDate: new Date('2020-08-03'),
-		content: '부업',
-		id: 4,
-		payment: '현금',
-		price: 6000,
-	},
-];
-export default class MainPanel extends Component {
+class MainPanel extends Component {
 	dom: HTMLElement;
-	contents: Array<AbstractContent> = [];
+	monthSelector: any | null;
+	tabSelector: any | null;
+	contents: Map<String, AbstractContent>;
+	router: any;
 
 	constructor() {
 		super();
 		this.dom = document.createElement('main');
+		this.contents = new Map<String, AbstractContent>();
 		this.dom.classList.add('main-panel');
+		this.monthSelector = null;
+		this.tabSelector = null;
+		this.router = null;
 		this.init();
+		this.listener();
 	}
 
 	init() {
-		let curMonth = 6;
-		const monthSelector = new MonthSelector(6, (diff: number) => {
+		const views = this.initViews();
+		this.router = new Router(views);
+
+		let curMonth = parseInt(this.router.getCurrentYearAndMonth().split('-')[1]);
+		this.monthSelector = new MonthSelector(curMonth, (diff: number) => {
 			curMonth += diff;
+			this.router.loadHistoryData(`2020-${curMonth}`);
+			this.router.updateCurrentUrl();
 			return curMonth;
 		});
 
-		const tabSelector = new TabSelector((tab) => {
+		this.tabSelector = new TabSelector((tab) => {
 			console.log(tab);
+
+			let page = '';
+			switch (tab) {
+				case '내역':
+					page = 'history';
+					break;
+				case '달력':
+					page = 'calendar';
+					break;
+				case '통계':
+					page = 'graph';
+					break;
+				default:
+					throw new Error('no tab exists');
+			}
+			this.router.loadView(page);
+			this.router.updateCurrentUrl();
 			alert(`Move to ${tab} tab`);
 		});
 
-		this.getDom().appendChild(monthSelector.getDom());
-		this.getDom().appendChild(tabSelector.getDom());
-		this.contents.push(new HistoryContent());
-		this.dom.appendChild(this.contents[0].getDom());
-		/**
-		 * todo
-		 * 달력 content, 통계 content appendChild
-		 */
-		this.contents[0].load(testHistory);
+		this.getDom().appendChild(this.monthSelector.getDom());
+		this.getDom().appendChild(this.tabSelector.getDom());
+	}
+
+	private initViews(): Array<View> {
+		const views = [] as Array<View>;
+		const histroyView = { viewName: 'history', component: new HistoryContent() };
+		const calendarView = { viewName: 'calendar', component: new HistoryContent() };
+		const graphView = { viewName: 'graph', component: new HistoryContent() };
+
+		views.push(histroyView);
+		views.push(calendarView);
+		views.push(graphView);
+
+		return views;
+	}
+
+	private listener() {
+		window.addEventListener('popstate', this.popStateHandler.bind(this));
+	}
+
+	/**
+	 * TODO
+	 * router 내로 옮기고 tabSelector와 monthSelector가 router를 구독하게?
+	 */
+	private async popStateHandler() {
+		const routeArr = location.pathname.replace('/', '').split('/');
+		const serviceId = parseInt(routeArr[0], 16) - 3000;
+		const yearAndMonth = routeArr[1];
+		const page = routeArr[2];
+		this.router.setCurrent({ serviceId, yearAndMonth, page });
+		console.info('popstate', { serviceId, yearAndMonth, page });
+
+		let tabName;
+		switch (page) {
+			case 'history':
+				tabName = '내역';
+				break;
+			case 'calendar':
+				tabName = '달력';
+				break;
+			case 'graph':
+				tabName = '통계';
+				break;
+			default:
+				throw new Error('no pageName for tab');
+		}
+
+		this.monthSelector?.setMonth(yearAndMonth.split('-')[1]);
+		this.tabSelector.setHighlight(tabName);
+		this.router.loadView(page);
 	}
 }
+
+export default MainPanel;

--- a/client/src/components/month-selector/month-selector.ts
+++ b/client/src/components/month-selector/month-selector.ts
@@ -1,6 +1,7 @@
 import Component from '../component';
 
 export default class MonthSelector extends Component {
+	dom: HTMLElement;
 	private month: number;
 	private onMoveMonth: (diffMonth: number) => number;
 	// TODO: display year
@@ -20,22 +21,35 @@ export default class MonthSelector extends Component {
 
 	init(): void {
 		this.render();
-		this.dom?.querySelector('#goto_prev_month_button')?.addEventListener('click', () => {
+		this.listener();
+	}
+
+	listener() {
+		const prevBtn = this.dom.querySelector('#goto_prev_month_button') as HTMLButtonElement;
+		const nextBtn = this.dom.querySelector('#goto_next_month_button') as HTMLButtonElement;
+		const monthArea = this.dom.querySelector('span') as HTMLSpanElement;
+		prevBtn.addEventListener('click', () => {
 			this.month = this.onMoveMonth(-1);
-			this.init();
+			monthArea.innerHTML = `${this.month} 월`;
 		});
 
-		this.dom?.querySelector('#goto_next_month_button')?.addEventListener('click', () => {
+		nextBtn.addEventListener('click', () => {
 			this.month = this.onMoveMonth(1);
-			this.init();
+			monthArea.innerHTML = `${this.month} 월`;
 		});
 	}
 
 	render(): void {
-		this.dom!.innerHTML = `
+		this.dom.innerHTML = `
         <button id="goto_prev_month_button">◁</button>
         <span>${this.month} 월</span>
         <button id="goto_next_month_button">▷</button>
         `;
+	}
+
+	public setMonth(month: number) {
+		this.month = month;
+		const monthArea = this.dom.querySelector('span') as HTMLSpanElement;
+		monthArea.innerHTML = `${this.month} 월`;
 	}
 }

--- a/client/src/components/tab-selector/tab-selector.ts
+++ b/client/src/components/tab-selector/tab-selector.ts
@@ -2,6 +2,7 @@ import Component from '../component';
 
 export default class TabSelector extends Component {
 	// Remove hardcoded tab data
+	dom: HTMLElement;
 	private tabs: string[] = ['내역', '달력', '통계'];
 	private onMoveTab: (tab: string) => void;
 	constructor(onMoveTab: (tab: string) => void) {
@@ -14,16 +15,25 @@ export default class TabSelector extends Component {
 
 	init(): void {
 		this.render();
-		this.dom?.addEventListener('click', (evt: any) => {
-			const tabName = evt.target.dataset.name;
+		this.listener();
+	}
+
+	listener() {
+		this.dom.addEventListener('click', (evt: Event) => {
+			const targetDom = evt.target as HTMLElement;
+			const tabName = targetDom.dataset.name;
 			if (!tabName) return;
-			this.dom?.querySelector('.tab-highlight');
 			this.onMoveTab(tabName);
-			const highlight: any = this.dom?.querySelector('.tab-highlight') as any;
-			const index = this.tabs.indexOf(tabName);
-			//TODO 위치 조절 필요
-			highlight.style.transform = `translateX(${index * 5}rem)`;
+			this.setHighlight(tabName);
 		});
+	}
+
+	//TODO 위치 조절 필요
+	setHighlight(page: string) {
+		const index = this.tabs.indexOf(page);
+		const highlight = this.dom.querySelector('.tab-highlight') as HTMLElement;
+		highlight.style.transform = `translateX(${index * 5}rem)`;
+		//TODO style -> css로 넣어야됩니다.
 	}
 
 	render(): void {

--- a/client/src/pages/not-found.ts
+++ b/client/src/pages/not-found.ts
@@ -1,0 +1,4 @@
+const NotFoundPage = document.createElement('div');
+NotFoundPage.innerHTML = `<h1>Not Found Page</h1>`;
+
+export default NotFoundPage;

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -1,0 +1,152 @@
+import { AbstractContent } from './components/content/abstract-content';
+import NotFoundPage from './pages/not-found';
+import { History } from './components/content/abstract-content';
+
+const testHistory: History[] = [
+	{
+		category: '밥',
+		historyDate: new Date('2020-08-01'),
+		content: '순댓국',
+		id: 1,
+		payment: '외상',
+		price: -4000,
+	},
+	{
+		category: '주식',
+		historyDate: new Date('2020-08-01'),
+		content: '상장폐지',
+		id: 2,
+		payment: '주식',
+		price: -5000,
+	},
+	{
+		category: '밥',
+		historyDate: new Date('2020-08-01'),
+		content: '순댓국1',
+		id: 3,
+		payment: '외상',
+		price: -3000,
+	},
+	{
+		category: '일',
+		historyDate: new Date('2020-08-03'),
+		content: '부업',
+		id: 4,
+		payment: '현금',
+		price: 6000,
+	},
+];
+
+interface View {
+	viewName: string;
+	component: AbstractContent;
+}
+
+interface CurrentData {
+	serviceId: number;
+	yearAndMonth: string;
+	page: string;
+}
+
+class Router {
+	private views: Map<String, AbstractContent>;
+	private root: string;
+	private current: CurrentData;
+
+	constructor(pages: Array<View>) {
+		this.views = new Map<String, AbstractContent>();
+		this.root = '/';
+		const now = new Date();
+		this.current = {
+			serviceId: 1,
+			yearAndMonth: now.getFullYear() + '-' + now.getMonth() + 1,
+			page: 'history',
+		};
+		this.init(pages);
+	}
+
+	private async init(pages: Array<View>) {
+		pages.forEach((page) => this.addView(page.viewName, page.component));
+
+		const routeArr = location.pathname.replace(this.root, '').split('/');
+		if (routeArr.length !== 3) {
+			this.loadView('not-found');
+			return;
+		}
+
+		const serviceId = parseInt(routeArr[0], 16) - 3000;
+		const yearAndMonth = routeArr[1];
+		const page = routeArr[2];
+
+		await this.loadHistoryData(yearAndMonth, serviceId);
+		this.loadView(page);
+		this.updateCurrentUrl();
+	}
+
+	private addView(viewName: string, component: AbstractContent): void {
+		this.views.set(viewName, component);
+	}
+
+	private getView(viewName: string): AbstractContent | null {
+		if (this.views.has(viewName)) {
+			return this.views.get(viewName) as AbstractContent;
+		} else {
+			return null;
+		}
+	}
+
+	public loadView(page: string) {
+		const mainPanel = document.querySelector('main') as HTMLElement;
+		const matchedView = this.getView(page);
+		if (matchedView) {
+			while (mainPanel.childElementCount !== 2) {
+				mainPanel.lastElementChild?.remove();
+			}
+			mainPanel.appendChild(matchedView.getDom());
+			this.current.page = page;
+		} else {
+			const app = document.querySelector('#app') as HTMLElement;
+			const url = `${this.root}not-found`;
+			app.innerHTML = NotFoundPage.innerHTML;
+			history.pushState({}, '', url);
+		}
+	}
+
+	public async loadHistoryData(
+		yearAndMonth: string = this.current.yearAndMonth,
+		serviceId: number = this.current.serviceId
+	) {
+		//todo 뷰의 데이터 전부 로드
+		this.views.get(this.current.page)!.load(testHistory);
+
+		this.current.serviceId = serviceId;
+		this.current.yearAndMonth = yearAndMonth;
+	}
+
+	public updateCurrentUrl() {
+		console.info(
+			'pushstate',
+			`${this.root}${(this.current.serviceId + 3000).toString(16)}/${this.current.yearAndMonth}/${
+				this.current.page
+			}`
+		);
+		history.pushState(
+			null,
+			'',
+			`${this.root}${(this.current.serviceId + 3000).toString(16)}/${this.current.yearAndMonth}/${
+				this.current.page
+			}`
+		);
+	}
+
+	public setCurrent(current: CurrentData) {
+		this.current = current;
+	}
+
+	public getCurrentYearAndMonth() {
+		return this.current.yearAndMonth;
+	}
+}
+
+export { View };
+export default Router;

--- a/client/webpack.config.dev.js
+++ b/client/webpack.config.dev.js
@@ -45,12 +45,4 @@ module.exports = {
 			},
 		],
 	},
-	plugins: [
-		new HtmlWebpackPlugin({
-			template: path.resolve(__dirname, './public/index.html'),
-			filename: path.resolve(__dirname, '../server/public/index.html'),
-			inject: true, // inject built script in the end of body tag
-			alwaysWriteToDisk: true,
-		}),
-	],
 };

--- a/client/webpack.config.production.js
+++ b/client/webpack.config.production.js
@@ -38,12 +38,6 @@ module.exports = {
 		new MiniCssExtractPlugin({
 			filename: 'style.css',
 		}),
-		new HtmlWebpackPlugin({
-			template: path.resolve(__dirname, './public/index.html'),
-			filename: path.resolve(__dirname, '../server/public/index.html'),
-			inject: true, // inject built script in the end of body tag
-			alwaysWriteToDisk: true,
-		}),
 		new HtmlWebpackHarddiskPlugin(),
 	],
 };

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -12,5 +12,6 @@
 
 	<body>
 		<div id="app"></div>
-	<script src="static/bundle.js"></script></body>
+		<script src="/static/bundle.js"></script>
+	</body>
 </html>

--- a/server/src/config/express.ts
+++ b/server/src/config/express.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import bodyParser from 'body-parser';
 import morgan from 'morgan';
 import compression from 'compression';
@@ -10,14 +10,7 @@ import { logs } from './consts';
 import errorHandler from '../exception/error-handler';
 import passport from 'passport';
 import strategies from '../modules/auth/passport';
-import {
-	router,
-	authRouter,
-	userRouter,
-	serviceRouter,
-	categoryRouter,
-	paymentRouter,
-} from '../router';
+import router from '../router';
 
 const app = express();
 app.use(morgan(logs, { stream: new LoggerStream() }));
@@ -37,12 +30,6 @@ passport.use(strategies.jwt);
 passport.use(strategies.google);
 
 app.use('/', router);
-app.use('/api/auth', authRouter);
-app.use('/api/user', userRouter);
-app.use('/api/service', serviceRouter);
-app.use('/api/category', categoryRouter);
-app.use('/api/payment', paymentRouter);
-
 app.use(errorHandler);
 
 export default app;

--- a/server/src/router/index.ts
+++ b/server/src/router/index.ts
@@ -1,13 +1,19 @@
+import { Router, Request, Response, NextFunction } from 'express';
 import userRouter from './user-router';
 import authRouter from './auth-router';
 import serviceRouter from './service-router';
 import categoryRouter from './category-router';
 import paymentRouter from './payment-router';
-import { Router, Request, Response, NextFunction } from 'express';
 
 const router = Router();
-router.route('/').get((req: Request, res: Response, next: NextFunction) => {
+
+router.use('/api/user', userRouter);
+router.use('/api/auth', authRouter);
+router.use('/api/service', serviceRouter);
+router.use('/api/category', categoryRouter);
+router.use('/api/payment', paymentRouter);
+router.use((req: Request, res: Response, next: NextFunction) => {
 	res.render('index');
 });
 
-export { router, userRouter, authRouter, serviceRouter, categoryRouter, paymentRouter };
+export default router;


### PR DESCRIPTION
## 설명
- 클라이언트 사이드 라우팅 구현
- 주소창 입력시 push state, 그리고 화면 데이터 및 뷰 초기화
- popstate 시 url에 해당하는 month selector, tab selector, view 설정
- webpack에 의해 불필요한 html파일 재 생성을 제거했습니다. html 파일을 서버로 옮기고 js파일 절대경로로 변경
- 서버 라우팅에서 api 제외 모든 요청 html 파일 전송
- 불필요한 로그 출력 제거

## 관련 이슈
- resolved #14

## 기타(스크린샷 등)
